### PR TITLE
default.nix: Add the packages: pylint, autopep8

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -50,6 +50,10 @@ let
     treelib
     urwid
     werkzeug
+
+    # not strictly required:
+    pylint
+    autopep8
   ];
 
 in buildEnv {


### PR DESCRIPTION
This way, the linter and formatter can be used within the nix environment.
